### PR TITLE
Refactor FindCommand.java to use streams

### DIFF
--- a/src/main/java/momo/commands/FindCommand.java
+++ b/src/main/java/momo/commands/FindCommand.java
@@ -1,6 +1,7 @@
 package momo.commands;
 
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 import momo.exceptions.MomoException;
 import momo.tasks.Task;
@@ -16,7 +17,6 @@ import momo.ui.Ui;
  */
 public class FindCommand extends Command {
     private final String keyword;
-    private ArrayList<Task> found;
 
     /**
      * Constructs a find command using the provided keyword.
@@ -25,7 +25,6 @@ public class FindCommand extends Command {
      */
     public FindCommand(String keyword) {
         this.keyword = keyword;
-        this.found = new ArrayList<>();
     }
 
     /**
@@ -38,13 +37,10 @@ public class FindCommand extends Command {
      */
     @Override
     public boolean execute(TaskManager taskManager, Ui ui) throws MomoException {
-        for (int i = 0; i < taskManager.getTaskListSize(); i++) {
-            Task task = taskManager.getTask(i);
-            String taskTitle = task.getTitle();
-            if (taskTitle.contains(keyword)) {
-                found.add(task);
-            }
-        }
+        ArrayList<Task> found = taskManager.getTasks().stream()
+            .filter(task -> task.getTitle().contains(keyword))
+            .collect(Collectors.toCollection(ArrayList::new));
+
         ui.showMatchingTaskList(found);
         return false;
     }

--- a/src/main/java/momo/tasks/TaskManager.java
+++ b/src/main/java/momo/tasks/TaskManager.java
@@ -74,6 +74,15 @@ public class TaskManager {
     }
 
     /**
+     * Returns an array of the tasks currently managed.
+     *
+     * @return A new arraylist of tasks.
+     */
+    public ArrayList<Task> getTasks() {
+        return new ArrayList<>(taskList);
+    }
+
+    /**
      * Returns the number of tasks currently managed.
      *
      * @return Size of the task list.


### PR DESCRIPTION
FindCommand currently uses an index-based
loop to collect matching tasks.

Manual iteration makes the filtering logic
more verbose than necessary.

Replace loop with Stream API for filtering
and collecting matching tasks.

Expose an unmodifiable task list from
TaskManager to preserve encapsulation.

No change in behaviour.